### PR TITLE
ci: harden release validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 <!-- Brief description of the change and its motivation. Link related issues with #123. -->
 
+## Related issues
+
+Refs #
+
 ## Checklist
 
 - [ ] `pnpm build` and `pnpm test` pass locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Unit tests
+        run: pnpm test
+
       # 类型检查 + 构建产物完整性（package.json build = vue-tsc --noEmit && vite build）
       - name: Typecheck & build
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,13 +167,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; refusing to modify its assets." >&2
+            exit 1
+          fi
+          ASSETS=(
+            src-tauri/target/release/bundle/dmg/*.dmg
+            src-tauri/target/release/bundle/updater/*.app.tar.gz
+            src-tauri/target/release/bundle/updater/*.sig
+            src-tauri/target/release/bundle/updater/latest.json
+            windows-artifacts/*.exe
+            windows-artifacts/*.sig
+          )
           gh release create "$GITHUB_REF_NAME" \
+            --verify-tag \
             --draft \
             --title "Monet ${GITHUB_REF_NAME}" \
             --generate-notes \
-            src-tauri/target/release/bundle/dmg/*.dmg \
-            src-tauri/target/release/bundle/updater/*.app.tar.gz \
-            src-tauri/target/release/bundle/updater/*.sig \
-            src-tauri/target/release/bundle/updater/latest.json \
-            windows-artifacts/*.exe \
-            windows-artifacts/*.sig
+            "${ASSETS[@]}"

--- a/src-tauri/src/routine_env.rs
+++ b/src-tauri/src/routine_env.rs
@@ -27,6 +27,7 @@ fn invalid_data(message: impl Into<String>) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, message.into())
 }
 
+#[allow(dead_code)]
 fn write_synced(path: &Path, content: &str) -> std::io::Result<()> {
     let mut file = OpenOptions::new()
         .create(true)
@@ -37,6 +38,7 @@ fn write_synced(path: &Path, content: &str) -> std::io::Result<()> {
     file.sync_all()
 }
 
+#[allow(dead_code)]
 fn publish_snapshot(path: &Path, content: &str) -> std::io::Result<()> {
     let tmp = path.with_extension(format!("json.tmp{}", std::process::id()));
     if let Err(error) = write_synced(&tmp, content).and_then(|_| replace_file(&tmp, path)) {
@@ -51,6 +53,7 @@ fn publish_snapshot(path: &Path, content: &str) -> std::io::Result<()> {
 }
 
 #[cfg(windows)]
+#[allow(dead_code)]
 fn replace_file(source: &Path, target: &Path) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::{
@@ -74,10 +77,12 @@ fn replace_file(source: &Path, target: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(not(windows))]
+#[allow(dead_code)]
 fn replace_file(source: &Path, target: &Path) -> std::io::Result<()> {
     fs::rename(source, target)
 }
 
+#[allow(dead_code)]
 pub fn prepare_claude_config_dir<F, G>(
     data_dir: &Path,
     claude_config_dir: Option<&str>,
@@ -92,6 +97,7 @@ where
     fs::create_dir_all(data_dir)?;
     let lock = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(lock_path(data_dir))?;
@@ -138,13 +144,15 @@ where
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn read_claude_config_dir(data_dir: &Path) -> std::io::Result<Option<String>> {
     let lock = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(lock_path(data_dir))?;
-    lock.lock_shared()?;
+    FileExt::lock_shared(&lock)?;
 
     let content = fs::read_to_string(snapshot_path(data_dir))?;
     let environment: RoutineEnvironment =


### PR DESCRIPTION
## Summary

- run unit tests in the main CI workflow
- refuse to overwrite an existing release when a tag workflow is rerun
- verify the release tag before creating the Draft Release
- add a neutral Issue reference field to the pull request template
- keep the shared Routine lock module compatible with the project MSRV under strict Clippy checks

## Verification

- `pnpm test`
- `cargo test --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- workflow YAML parsing
- `git diff --check`

Refs #